### PR TITLE
Bugfix + new anti-disassembly technique (#245)

### DIFF
--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -298,6 +298,10 @@ int main(void)
 		AntiDisassmFunctionPointer();
 		_tprintf(_T("Begin AntiDisassmReturnPointerAbuse\n"));
 		AntiDisassmReturnPointerAbuse();
+#ifndef _WIN64
+		_tprintf(_T("Begin AntiDisassmSEHMisuse\n"));
+		AntiDisassmSEHMisuse();
+#endif
 	}
 
 	/* Anti Dumping */

--- a/al-khaser/AntiDebug/TrapFlag.cpp
+++ b/al-khaser/AntiDebug/TrapFlag.cpp
@@ -6,7 +6,7 @@
 	This technique is similar to exceptions based debugger detections.
 	You enable the trap flag in the current process and check whether
 	an exception is raised or not. If an exception is not raised, you
-	can assume that a debugger has “swallowed” the exception for us,
+	can assume that a debugger has â€œswallowedâ€ the exception for us,
 	and that the program is being traced. The beauty of this approach
 	is that it detects every debugger, user mode or kernel mode,
 	because they all use the trap flag for tracing a program.
@@ -22,16 +22,10 @@ static LONG CALLBACK VectoredHandler(
 )
 {
 	SwallowedException = FALSE;
+	
 	if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_SINGLE_STEP)
-	{
-		//Increase EIP/RIP to continue execution.
-#ifdef _WIN64
-		ExceptionInfo->ContextRecord->Rip++;
-#else
-		ExceptionInfo->ContextRecord->Eip++;
-#endif
 		return EXCEPTION_CONTINUE_EXECUTION;
-	}
+		
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 

--- a/al-khaser/AntiDisassm/AntiDisassm.cpp
+++ b/al-khaser/AntiDisassm/AntiDisassm.cpp
@@ -8,6 +8,9 @@ extern "C" void __AsmJmpSameTarget();
 extern "C" void __AsmImpossibleDisassm();
 extern "C" void __AsmFunctionPointer(DWORD);
 extern "C" void __AsmReturnPointerAbuse(DWORD64);
+#ifndef _WIN64
+extern "C" void __AsmSEHMisuse();
+#endif
 
 /*
 	This technique is composed of a single conditional jump instruction placed where the condition
@@ -62,3 +65,10 @@ VOID AntiDisassmReturnPointerAbuse()
 {
 	__AsmReturnPointerAbuse(666);
 }
+
+#ifndef _WIN64
+VOID AntiDisassmSEHMisuse()
+{
+	__AsmSEHMisuse();
+}
+#endif

--- a/al-khaser/AntiDisassm/AntiDisassm.h
+++ b/al-khaser/AntiDisassm/AntiDisassm.h
@@ -5,3 +5,4 @@ VOID AntiDisassmAsmJmpSameTarget();
 VOID AntiDisassmImpossibleDiasassm();
 VOID AntiDisassmFunctionPointer();
 VOID AntiDisassmReturnPointerAbuse();
+VOID AntiDisassmSEHMisuse();

--- a/al-khaser/AntiDisassm/AntiDisassm_x86.asm
+++ b/al-khaser/AntiDisassm/AntiDisassm_x86.asm
@@ -78,6 +78,34 @@ __AsmReturnPointerAbuse proc
 	retn
 __AsmReturnPointerAbuse endp
 
+; another dummy function
+func3 proc 
+	mov esp, [esp+8]
+	ASSUME FS:NOTHING
+	mov eax, dword ptr fs:[0]
+	ASSUME FS:ERROR
+	mov eax, [eax]
+	mov eax, [eax]
+	ASSUME FS:NOTHING
+	mov dword ptr fs:[0], eax
+	ASSUME FS:ERROR
+	add esp, 8
+	pop ebp
+	retn
+ func3 endp
 
+__AsmSEHMisuse proc
+	push ebp
+	mov eax, offset func3
+	push eax
+	ASSUME FS:NOTHING
+	push dword ptr fs:[0]
+	mov dword ptr fs:[0], esp
+	ASSUME FS:ERROR
+	xor ecx, ecx
+	div ecx
+	call func2
+	retn
+__AsmSEHMisuse endp
 
 end

--- a/al-khaser/al-khaser.vcxproj
+++ b/al-khaser/al-khaser.vcxproj
@@ -96,6 +96,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -138,6 +139,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Command>copy $(OutDir)$(AssemblyName).exe $(SolutionDir)$(AssemblyName)_$(PlatformTarget).exe</Command>


### PR DESCRIPTION
* Disable optimization to avoid crash in GetProcAddress

* Adding the SEH misuse anti-disassembly technique

* Fix messed-up stack after execution of VectoredHandler in TrapFlag.cpp

* Fix messed-up stack after executing the SEH misuse anti-disassembly technique

* Fix VectoredHandler for x64 architectures

Co-authored-by: Fulvio Di Girolamo <fulviodigirolamo@tutanota.com>
Co-authored-by: Fulvio Di Girolamo <fulviodig96@gmail.com>